### PR TITLE
Config: queryWrapper 리팩토링

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -21,17 +21,17 @@ class UserController implements IUserController {
       throw new BadReqError();
     }
     const user = await this.userService.findOne(parsedInt);
-    if (!user || user.length < 1) {
+    if (!user) {
       throw new NotFoundError();
     }
 
-    return res.json({ user: user[0] }).status(200);
+    return res.json({ user }).status(200);
   };
 
   findAll = async (_: Request, res: Response<{ users: IUser[] }>) => {
     const users = await this.userService.findAll();
 
-    if (!users || users.length < 1) {
+    if (!users) {
       throw new NotFoundError();
     }
     return res.json({ users });

--- a/src/daos/user.dao.ts
+++ b/src/daos/user.dao.ts
@@ -6,12 +6,16 @@ import { MySQL, queryWrapper } from "../utils";
 class UserDAO implements IUserDAO {
   constructor(private readonly mysql: MySQL) {}
 
-  async findOne(id: number): Promise<IUser[] | undefined> {
+  async findOne(id: number): Promise<IUser | undefined> {
     const conn = await this.mysql.getConnection();
     const query = "Select * FROM users WHERE id=?";
     const values = [String(id)];
+    const result = await queryWrapper<IUser>({ query, values }, conn!);
 
-    return queryWrapper<IUser[]>({ query, values }, conn!);
+    if (!result) {
+      return undefined;
+    }
+    return result[0];
   }
 
   async findAll(): Promise<IUser[] | undefined> {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -7,7 +7,7 @@ import { UserDAO } from "../daos";
 class UserService implements IUserService {
   constructor(private userDAO: UserDAO) {}
 
-  findOne(id: number): Promise<IUser[] | undefined> {
+  findOne(id: number): Promise<IUser | undefined> {
     return this.userDAO.findOne(id);
   }
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -20,12 +20,12 @@ export interface FindUserByIdDTO {
 }
 
 export interface IUserDAO {
-  findOne: (id: number) => Promise<IUser[] | undefined>;
+  findOne: (id: number) => Promise<IUser | undefined>;
   findAll: (id: string) => Promise<IUser[] | undefined>;
 }
 
 export interface IUserService {
-  findOne: (id: number) => Promise<IUser[] | undefined>;
+  findOne: (id: number) => Promise<IUser | undefined>;
   findAll: () => Promise<IUser[] | undefined>;
 }
 

--- a/src/utils/mysql-connection-wrapper.ts
+++ b/src/utils/mysql-connection-wrapper.ts
@@ -1,16 +1,15 @@
-import type { PoolConnection, RowDataPacket, OkPacket } from "mysql2/promise";
+import type { PoolConnection } from "mysql2/promise";
 
-type dbDefaults = RowDataPacket[] | RowDataPacket[][] | OkPacket | OkPacket[];
-type dbQuery<T> = T & dbDefaults;
+type AlwaysArray<T> = T extends (infer R)[] ? R[] : T[];
 
 // eslint-disable-next-line consistent-return
 export async function queryWrapper<T>(
   { query, values }: { query: string; values?: string[] },
   conn: PoolConnection
-): Promise<T | undefined> {
+): Promise<AlwaysArray<T> | undefined> {
   try {
     await conn.beginTransaction();
-    const [rows, _] = await conn.query<dbQuery<T>>(query, values || undefined);
+    const [rows, _]: [any, any] = await conn.query(query, values);
     await conn.commit();
 
     return rows;


### PR DESCRIPTION
## 문제
Single Row를 select 해도 배열을 반환하는 문제

예시 
```
const result = queryWrapper<IUser>({ query, values }, conn!);
```
123
```
[
  {
    name: "user_name",
    email: "user@gmail.com"
  }
]
```
## 해결
`queryWrapper` 함수의 반환타입을 배열로 제한하고 
DAO 층에서 배열의 `0`번 인덱스만 반환
