### PR TITLE
Chore: user 테이블 컬럼 수정

### DIFF
--- a/migrations/20220131122523-migrate.js
+++ b/migrations/20220131122523-migrate.js
@@ -33,7 +33,7 @@ exports.up = function (db) {
       CREATE TABLE if not exists user_metas (
         id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
         is_verified BOOLEAN DEFAULT false,
-        type VARCHAR(10) DEFAULT 'employee',
+        type VARCHAR(10) DEFAULT 'seeker',
         user_id BIGINT UNSIGNED NOT NULL,
 
         PRIMARY KEY (id),

--- a/src/constants/user.ts
+++ b/src/constants/user.ts
@@ -1,4 +1,4 @@
-export const USER_TYPE = ["employee", "employer"] as const;
+export const USER_TYPE = ["seeker", "company"] as const;
 
 export const USER_TABLE = "users";
 export const USER_METAS_TABLE = "user_metas";

--- a/src/services/tests/user/find-my-profile.service.test.ts
+++ b/src/services/tests/user/find-my-profile.service.test.ts
@@ -63,7 +63,7 @@ describe("findMyProfile Test", () => {
       })
     );
     expect(result.user_meta).toEqual(
-      expect.objectContaining({ is_verified: 0, type: "employee" })
+      expect.objectContaining({ is_verified: 0, type: "seeker" })
     );
   });
 });


### PR DESCRIPTION
# 작업
클라이언트와 타입 일치를 위해 users 테이블 컬럼 수정

* users 테이블의 `type` 컬럼 uinon 타입을 수정
* * `seeker`와 `companay`로 수정