### PR TITLE
Chore: 안전한 termination with pm2

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -4,6 +4,14 @@ module.exports = {
       name: "See Me", // pm2로 실행한 프로세스 목록에서 이 애플리케이션의 이름으로 지정될 문자열
       script: "./dist/index.js", // pm2로 실행될 파일 경로
       //   watch: true, // 파일이 변경되면 자동으로 재실행 (true || false)
+      node_args: "--max_old_space_size=4096",
+      wait_ready: true,
+      // 'ready' 이벤트를 기다릴 시간값
+      listen_timeout: 50000,
+      // SIGINT 시그널을 보낸 후 프로세스가 종료되지 않았을 때 SIGKILL 시그널을 보내기까지의 대기 시간을
+      // 디폴트 값 1600ms에서 5000ms로 변경할 수 있습니다.
+      kill_timeout: 5000,
+      //   max_memory_restart: "80M",
       env_production: {
         NODE_ENV: "production",
       },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@
 import type { Config } from "@jest/types";
 
 const config: Config.InitialOptions = {
+  clearMocks: true,
   preset: "ts-jest",
   testEnvironment: "node",
   moduleFileExtensions: ["js", "ts", "json"],
@@ -17,6 +18,9 @@ const config: Config.InitialOptions = {
   testTimeout: 30000,
   setupFilesAfterEnv: [
     "./jest/jest.setup.logger.ts",
+    "./jest/jest.setup.set-off-keep-alive.ts",
+    "./jest/jest.setup.terminus.ts",
+    "./jest/jest.setup.health-check.ts",
     "./jest/jest.setup.redis-mock.ts",
     "./jest/jest.setup.passport.ts",
     "./jest/jest.setup.aws-sdk.ts",

--- a/jest/jest.setup.health-check.ts
+++ b/jest/jest.setup.health-check.ts
@@ -1,0 +1,3 @@
+jest.mock("../src/utils/health-check.ts", () => {
+  return { terminusOption: jest.fn() };
+});

--- a/jest/jest.setup.set-off-keep-alive.ts
+++ b/jest/jest.setup.set-off-keep-alive.ts
@@ -1,0 +1,3 @@
+jest.mock("../src/middlewares/set-off-keep-alive.ts", () => {
+  return { setOffKeepAlive: jest.fn() };
+});

--- a/jest/jest.setup.terminus.ts
+++ b/jest/jest.setup.terminus.ts
@@ -1,0 +1,3 @@
+jest.mock("@godaddy/terminus", () => {
+  return { createTerminus: jest.fn() };
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import passport from "passport";
 import session from "express-session";
 import cors from "cors";
 import helmet from "helmet";
+
 import routes from "./router";
 import { API_PREFIX, CORS_CONFIG, SESSION_OPTION } from "./config";
 import {
@@ -14,6 +15,7 @@ import {
   logMulterErrorMiddleware,
   logDbErrorMiddleware,
   logInternalServerErrorMiddleware,
+  setOffKeepAlive,
 } from "./middlewares";
 import passportConfig from "./passports";
 import { MySQL, Redis } from "./db";
@@ -28,6 +30,8 @@ export async function startApp() {
 
   const mysql = Container.get(MySQL);
   await mysql.connect();
+
+  setOffKeepAlive(app);
 
   app.use(helmet());
 
@@ -46,12 +50,6 @@ export async function startApp() {
   app.use(passport.initialize());
   app.use(passport.session());
   app.use(loggingReq);
-
-  //   app.get("/health", async (_, res) => {
-  //     const t1 = await mysql.getHealthCheck();
-  //     const t2 = await redis.getHealthCheck();
-  //     res.json({ status: "ok", t1, t2 });
-  //   });
 
   app.use(API_PREFIX, routes);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { startApp } from "./app";
 import { PORT } from "./config";
 // import { PORT, HTTPS_PORT } from "./config";
 import { logger } from "./utils";
-import { terminusOption } from "./health-check";
+import { terminusOption } from "./utils/health-check";
 
 startApp().then((app) => {
   //   const option = {
@@ -27,12 +27,20 @@ startApp().then((app) => {
   createTerminus(server, terminusOption);
 
   server.listen(PORT, () => {
+    (<any>process).send("ready");
     logger.info(`
             ################################################
             🛡️ HTTP  Server listening on port: ${PORT} / ${process.env.NODE_ENV} 🛡️
             ################################################
                 `);
   });
+
+  // terminus 가 close 해줄듯?
+  //   server.close(() => {
+  //     console.log("server closed");
+  //     process.exit(0);
+  //   });
+
   //   app.listen(PORT, () => {
   //     logger.info(`
   //             ################################################

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -2,3 +2,4 @@ export * from "./loggingReq";
 export * from "./error-handler";
 export * from "./auth";
 export * from "./multer";
+export * from "./set-off-keep-alive";

--- a/src/middlewares/set-off-keep-alive.ts
+++ b/src/middlewares/set-off-keep-alive.ts
@@ -1,0 +1,19 @@
+import Container from "typedi";
+import { Application } from "express";
+import { Emitter, logger } from "../utils";
+
+export function setOffKeepAlive(app: Application) {
+  const emitter = Container.get(Emitter).getInstance();
+  let isDisableKeepAlive = false;
+  emitter.on("offKeepAlive", () => {
+    isDisableKeepAlive = true;
+    logger.info("Set off 'keep-alive' header");
+  });
+
+  app.use((_, res, next) => {
+    if (isDisableKeepAlive) {
+      res.set("Connection", "close");
+    }
+    next();
+  });
+}

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,0 +1,15 @@
+import EventEmitter from "events";
+import { Service } from "typedi";
+
+@Service()
+export class Emitter {
+  emitter;
+
+  constructor() {
+    this.emitter = new EventEmitter();
+  }
+
+  getInstance() {
+    return this.emitter;
+  }
+}

--- a/src/utils/health-check.ts
+++ b/src/utils/health-check.ts
@@ -1,11 +1,14 @@
 import { HealthCheckError, TerminusOptions } from "@godaddy/terminus";
 import Container from "typedi";
-import { MySQL, Redis } from "./db";
-import { logger } from "./utils";
+import { MySQL, Redis } from "../db";
+import { logger, Emitter } from ".";
 
 const redis = Container.get(Redis);
 const mysql = Container.get(MySQL);
+const emitter = Container.get(Emitter).getInstance();
+
 function onSignal() {
+  emitter.emit("offKeepAlive");
   return Promise.all([mysql.closePool(), redis.closeRedis()]);
 }
 
@@ -40,5 +43,5 @@ export const terminusOption: TerminusOptions = {
   },
   onShutdown,
   onSignal,
-  timeout: 1000,
+  timeout: 5000,
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,5 @@ export * from "./hashing-password";
 export * from "./convert-date-to-timestamp";
 export * from "./assert-non-nullish";
 export * from "./parse-to-nuber-or-throw";
+export * from "./event";
+export * from "./health-check";


### PR DESCRIPTION
# 작업
CD 할 때 더 안전적인 서버 종료를 위한 설정

* pm2 에서 `SIGINT`를 보내줄 때 프로세스 종료 까지의 대기 시간 변경
* `connection`의 `keep-alive`를 `close`로 변경
